### PR TITLE
Exclude certain ACM namespaces from network policy

### DIFF
--- a/bundles/cis-k8s-1.5.1/5.3.2_require-namespace-network-policies.yaml
+++ b/bundles/cis-k8s-1.5.1/5.3.2_require-namespace-network-policies.yaml
@@ -8,3 +8,9 @@ metadata:
     bundles.validator.forsetisecurity.org/cis-k8s-v1.5.1: 5.3.2
 spec:
   enforcementAction: dryrun # kpt-set: ${enforcementAction}
+  match:
+    excludedNamespaces:
+      - kube-system
+      - config-management-system
+      - config-management-monitoring
+      - resource-group-system


### PR DESCRIPTION
The require-namespace-network-policies constraint requires that every
namespace in the cluster have a NetworkPolicy object defined.

Certain ACM products don't include such a NetworkPolicy, and are thus
broken by this Constraint if it is applied in its current state.

To solve this problem, this PR adds the following namespaces as
`excludedNamespaces` in the `match` section of the aforementioned
Constraint:

  - kube-system
  - config-management-system
  - config-management-monitoring
  - resource-group-system