### PR TITLE
feat:adds back the RBAC policies to the CIS bundle

### DIFF
--- a/bundles/cis-k8s-1.5.1/5.1.1_restrict-clusteradmin-rolebindings.yaml
+++ b/bundles/cis-k8s-1.5.1/5.1.1_restrict-clusteradmin-rolebindings.yaml
@@ -1,0 +1,46 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sRestrictRoleBindings
+metadata:
+  name: restrict-clusteradmin-rolebindings
+  annotations:
+    # This constraint is not certified by CIS.
+    description: "Restricts use of the cluster-admin role."
+    bundles.validator.forsetisecurity.org/cis-k8s-v1.5.1: 5.1.1
+spec:
+  enforcementAction: dryrun
+  parameters:
+    restrictedRole:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: cluster-admin
+    allowedSubjects:
+    - apiGroup: rbac.authorization.k8s.io
+      kind: Group
+      name: 'system:masters'
+    # for GKE Hub feature authorizer
+    - apiGroup: "rbac.authorization.k8s.io"
+      kind: "User"
+      name: "^service-[0-9]+@gcp-sa-gkehub.iam.gserviceaccount.com$"
+      regexMatch: true
+    # for ACM to install in-cluster resources
+    - apiGroup: "rbac.authorization.k8s.io"
+      kind: "User"
+      name: "^service-[0-9]+@gcp-sa-anthosconfigmanagement.iam.gserviceaccount.com$"
+      regexMatch: true
+    # for Config Sync reconciler service account
+    - kind: "ServiceAccount"
+      name: "reconciler-manager"

--- a/bundles/cis-k8s-1.5.1/5.1.3_prohibit-role-wildcard-access.yaml
+++ b/bundles/cis-k8s-1.5.1/5.1.3_prohibit-role-wildcard-access.yaml
@@ -1,0 +1,57 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sProhibitRoleWildcardAccess
+metadata:
+  name: prohibit-role-wildcard-access
+  annotations:
+    # This constraint is not certified by CIS.
+    description: "Restricts use of wildcards in Roles and ClusterRoles."
+    bundles.validator.forsetisecurity.org/cis-k8s-v1.5.1: 5.1.3
+spec:
+  enforcementAction: dryrun
+  match:
+    excludedNamespaces:
+    - gke-connect
+    - resource-group-system
+  parameters:
+    exemptions:
+      clusterRoles:
+        - name: "config-management-operator"
+        - name: "configsync.gke.io:ns-reconciler"
+        - name: "cluster-admin"
+        - name: "external-metrics-reader"
+        - name: "gatekeeper-manager-role"
+        - name: "istio-reader-clusterrole-asm-1124-1-istio-system"
+        - name: "istio-reader-istio-system"
+        - name: "istiod-clusterrole-asm-1124-1-istio-system"
+        - name: "istiod-istio-system"
+        - name: "kubelet-api-admin"
+        - name: "metering"
+        - name: "resource-group-manager-role"
+        - name: "system:controller:disruption-controller"
+        - name: "system:controller:generic-garbage-collector"
+        - name: "system:controller:horizontal-pod-autoscaler"
+        - name: "system:controller:namespace-controller"
+        - name: "system:controller:resourcequota-controller"
+        - name: "system:gcp-controller-manager"
+        - name: "system:gke-common-webhooks"
+        - name: "system:gke-hpa-actor"
+        - name: "system:gke-master-resourcequota"
+        - name: "system:glbc-status"
+        - name: "system:kube-controller-manager"
+        - name: "system:kubestore-collector"
+        - name: "system:kubelet-api-admin"
+        - name: "system:managed-certificate-controller"

--- a/bundles/cis-k8s-1.5.1/5.2.1_psp-privileged-container.yaml
+++ b/bundles/cis-k8s-1.5.1/5.2.1_psp-privileged-container.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bundles/cis-k8s-1.5.1/5.2.2-5.2.3_psp-host-namespace.yaml
+++ b/bundles/cis-k8s-1.5.1/5.2.2-5.2.3_psp-host-namespace.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bundles/cis-k8s-1.5.1/5.2.4_psp-host-network-ports.yaml
+++ b/bundles/cis-k8s-1.5.1/5.2.4_psp-host-network-ports.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bundles/cis-k8s-1.5.1/5.2.5_psp-allow-privilege-escalation-container.yaml
+++ b/bundles/cis-k8s-1.5.1/5.2.5_psp-allow-privilege-escalation-container.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bundles/cis-k8s-1.5.1/5.2.6_psp-restrict_root_containers.yaml
+++ b/bundles/cis-k8s-1.5.1/5.2.6_psp-restrict_root_containers.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bundles/cis-k8s-1.5.1/5.2.7-5.2.8-5.2.9_psp-capabilities.yaml
+++ b/bundles/cis-k8s-1.5.1/5.2.7-5.2.8-5.2.9_psp-capabilities.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bundles/cis-k8s-1.5.1/5.3.2_require-namespace-network-policies.yaml
+++ b/bundles/cis-k8s-1.5.1/5.3.2_require-namespace-network-policies.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bundles/cis-k8s-1.5.1/5.4.1_no-secrets-as-env-vars.yaml
+++ b/bundles/cis-k8s-1.5.1/5.4.1_no-secrets-as-env-vars.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bundles/cis-k8s-1.5.1/5.7.2_seccomp-docker-default.yaml
+++ b/bundles/cis-k8s-1.5.1/5.7.2_seccomp-docker-default.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bundles/cis-k8s-1.5.1/5.7.3_pods-require-security-context.yaml
+++ b/bundles/cis-k8s-1.5.1/5.7.3_pods-require-security-context.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bundles/cis-k8s-1.5.1/5.7.4_restrict-default-namespace.yaml
+++ b/bundles/cis-k8s-1.5.1/5.7.4_restrict-default-namespace.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
- adds policy 5.1.1 for restricting the use of cluster-admin
- adds policy 5.1.3 for prohibiting wildcard access
- updates copyright to 2022 