### PR TITLE
Update README for SEO and clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@
 
 [Policy Controller](https://cloud.google.com/anthos-config-management/docs/concepts/policy-controller), part of [Anthos Config Management](https://cloud.google.com/anthos-config-management/), is a Kubernetes [dynamic admission controller](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/) that checks, audits, and enforces your clusters' compliance with policies related to security, regulations, or arbitrary business rules.
 
-Policy Controller policies are broken up into two separate objects: `Constraint`s and `ConstraintTemplate`s. Having two distinct objects allows for separation of the policy **definition** ([`ConstraintTemplate`](https://cloud.google.com/anthos-config-management/docs/concepts/policy-controller#constraint_templates)) and policy **enforcement** ([`Constraint`](https://cloud.google.com/anthos-config-management/docs/concepts/policy-controller#constraints)).
+Policy Controller is based on the open source [Open Policy Agent Gatekeeper](https://github.com/open-policy-agent/gatekeeper) project. Gatekeeper policies are defined using two separate resource types: `Constraint`s and `ConstraintTemplate`s. Having two distinct resource types allows for separation of policy **definition** ([`ConstraintTemplate`](https://cloud.google.com/anthos-config-management/docs/concepts/policy-controller#constraint_templates)) from policy **enforcement** ([`Constraint`](https://cloud.google.com/anthos-config-management/docs/concepts/policy-controller#constraints)).
 
-This repository contains **sample** Constraints which can be used with the [library of ConstraintTemplates](https://cloud.google.com/anthos-config-management/docs/reference/constraint-template-library) built into Policy Controller.
+Policy Controller comes with a [library of ConstraintTemplates](https://cloud.google.com/anthos-config-management/docs/reference/constraint-template-library) for common security and compliance controls.
+
+This repository contains **sample** Constraints which make use of Policy Controller's ConstraintTemplates to demonstrate how you might configure policy enforcement on your own cluster.
 
 ## Bundles
 


### PR DESCRIPTION
Goals:
- Mention & link OPA Gatekeeper for SEO (mentioned in the official docs, so it's no secret)
- Make it clear that these Constraints depend on ConstraintTemplates that come with Policy Controller (and by implication wouldn't work with just OSS Gatekeeper by itself).
- Use "Resources" when talking about the types, as opposed to "Objects" which are the distinct instances of those types (according to REST conventions).