### PR TITLE
feat: Add "system:gke-vpa-target-reader" to K8sProhibitRoleWildcardAccess exceptions

### DIFF
--- a/anthos-bundles/nist-sp-800-190/restrict-role-wildcards.yaml
+++ b/anthos-bundles/nist-sp-800-190/restrict-role-wildcards.yaml
@@ -70,6 +70,7 @@ spec:
       - name: system:gke-common-webhooks
       - name: system:gke-hpa-actor
       - name: system:gke-master-resourcequota
+      - name: system:gke-vpa-target-reader
       - name: system:glbc-status
       - name: system:kube-controller-manager
       - name: system:kubestore-collector

--- a/anthos-bundles/nist-sp-800-53-r5/restrict-role-wildcards.yaml
+++ b/anthos-bundles/nist-sp-800-53-r5/restrict-role-wildcards.yaml
@@ -70,6 +70,7 @@ spec:
       - name: system:gke-common-webhooks
       - name: system:gke-hpa-actor
       - name: system:gke-master-resourcequota
+      - name: system:gke-vpa-target-reader
       - name: system:glbc-status
       - name: system:kube-controller-manager
       - name: system:kubestore-collector

--- a/bundles/cis-k8s-v1.5.1/5.1.3_prohibit-role-wildcard-access.yaml
+++ b/bundles/cis-k8s-v1.5.1/5.1.3_prohibit-role-wildcard-access.yaml
@@ -75,6 +75,7 @@ spec:
       - name: system:gke-common-webhooks
       - name: system:gke-hpa-actor
       - name: system:gke-master-resourcequota
+      - name: system:gke-vpa-target-reader
       - name: system:glbc-status
       - name: system:kube-controller-manager
       - name: system:kubestore-collector

--- a/bundles/policy-essentials-v2022/prohibit-role-wildcard-access.yaml
+++ b/bundles/policy-essentials-v2022/prohibit-role-wildcard-access.yaml
@@ -75,6 +75,7 @@ spec:
       - name: system:gke-common-webhooks
       - name: system:gke-hpa-actor
       - name: system:gke-master-resourcequota
+      - name: system:gke-vpa-target-reader
       - name: system:glbc-status
       - name: system:kube-controller-manager
       - name: system:kubestore-collector


### PR DESCRIPTION
After upgrading from GKE v1.24 to v1.27 I noticed that the new rule was added to the ClusterRole `system:gke-vpa-target-reader`:

```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: system:gke-vpa-target-reader
  # <...>
rules:
- apiGroups:
  - '*'
  resources:
  - '*/scale'
  verbs:
  - get
  - watch
# <...>
```
So now Policy Controller is complaining that it violates one of our `K8sProhibitRoleWildcardAccess` constraint. In our particular case it's `cis-k8s-v1.5.1/5.1.3_prohibit-role-wildcard-access.yaml`.

In this PR I'm adding the ClusterRole  `system:gke-vpa-target-reader` to the exception list of `K8sProhibitRoleWildcardAccess` in all bundles.

I found that this rule with a wildcard is supposed to be there intentionally - the official manifest from VPA contains it too:
https://github.com/kubernetes/autoscaler/blob/66b56c545165a6780227cb04d17bc5e3183bf50a/vertical-pod-autoscaler/deploy/vpa-rbac.yaml#L182-L189